### PR TITLE
Work around missing-non-nullable bug in Jackson.

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/entity/Project.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/entity/Project.kt
@@ -1,5 +1,6 @@
 package org.wycliffeassociates.resourcecontainer.entity
 
+import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import org.wycliffeassociates.resourcecontainer.Config
@@ -7,14 +8,35 @@ import org.wycliffeassociates.resourcecontainer.Config
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 data class Project(
-        var title: String = "",
-        var versification: String = "",
-        var identifier: String = "",
-        var sort: Int = 0,
-        var path: String = "",
-        var categories: List<String> = arrayListOf(),
-        var config: Config? = null
-)
+    var title: String = "",
+    var versification: String = "",
+    var identifier: String = "",
+    var sort: Int = 0,
+    var path: String = "",
+    var categories: List<String> = arrayListOf(),
+    var config: Config? = null
+) {
+    // Work around missing-non-nullable bug in Jackson: https://github.com/FasterXML/jackson-module-kotlin/issues/87
+    // Use an intermediate creator that will accept nulls and only pass them on if non-null.
+    @JsonCreator
+    private constructor(
+        title: String?,
+        versification: String?,
+        identifier: String?,
+        sort: Int?,
+        path: String?,
+        categories: List<String>?,
+        config: Config?
+    ) : this() {
+        title?.let { this.title = it }
+        versification?.let { this.versification = it }
+        identifier?.let { this.identifier = it }
+        sort?.let { this.sort = it }
+        path?.let { this.path = it }
+        categories?.let { this.categories = it }
+        config?.let { this.config = it }
+    }
+}
 
 fun project(init: Project.() -> Unit): Project {
     val project = Project()


### PR DESCRIPTION
Use an intermediate creator that will accept nulls and only pass them on if non-null, as a workaround for the following bug: https://github.com/FasterXML/jackson-module-kotlin/issues/87

The OBS sample file I found has a blank versification field, which triggers this issue and crashes Jackson-module-kotlin: https://git.door43.org/unfoldingWord/en_obs/src/commit/346ad59e8cc145c0d6310e94cd9f943ec4f48797/manifest.yaml