### PR TITLE
Remove compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
   - oraclejdk8
 before_cache:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/entity/Link.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/entity/Link.kt
@@ -159,27 +159,17 @@ class Link {
 
         }
 
-        /**
-         * Parses a resource container link
-         * @param title
-         * @param path
-         * @return
-         */
-        @Throws(Exception::class)
-        private fun parseResourceLink(title: String?, path: String): Link? {
-            var title = title
-            var path = path
+        /** Parses a resource container link */
+        private fun parseResourceLink(titleIn: String?, pathIn: String): Link? {
+            var title = titleIn
+            var path = pathIn
             val pattern = Pattern.compile("^((\\w+):)?\\/?(.*)", Pattern.DOTALL)
 
             var protocol: String? = null
             var language: String? = null
             var project: String? = null
             var resource: String? = null
-            var chapter: String? = null
-            var chunk: String? = null
-            var lastChunk: String? = null
             var arguments: String? = null
-
 
             // pull out the protocol
             // TRICKY: also pulls off the first / so our string splitting correctly finds the language
@@ -227,7 +217,9 @@ class Link {
             }
 
             // get chapter:chunk from arguments
-            chapter = arguments
+            var chapter: String? = arguments
+            var chunk: String? = null
+            var lastChunk: String? = null
             if (arguments != null && arguments.contains(":")) {
                 val bits = arguments.split(":".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
                 chapter = bits[0]
@@ -282,9 +274,8 @@ class Link {
          * @param text the text that will be searched for Bible passages
          * @return
          */
-        fun findLinks(text: CharSequence): List<Link>? {
-            // TODO: 10/11/16 automatically parse bible passages.
-            return null
+        fun findLinks(@Suppress("UNUSED_PARAMETER") text: CharSequence): List<Link> {
+            TODO("10/11/16 automatically parse bible passages.")
         }
     }
 }

--- a/src/test/kotlin/BookLinkTest.kt
+++ b/src/test/kotlin/BookLinkTest.kt
@@ -78,15 +78,11 @@ class BookLinkTest {
     @Throws(Exception::class)
     fun autoLink() {
         val links = Link.findLinks("Genesis 1:1")
-        if (links != null) {
-            assertEquals(1, links.size.toLong())
-            assertEquals("Genesis", links.get(0).project)
-            assertEquals("1:1", links.get(0).arguments)
-            assertEquals("1", links.get(0).chapter)
-            assertEquals("1", links.get(0).chunk)
-        } else {
-            throw Exception("Links is null.")
-        }
+        assertEquals(1, links.size.toLong())
+        assertEquals("Genesis", links.get(0).project)
+        assertEquals("1:1", links.get(0).arguments)
+        assertEquals("1", links.get(0).chapter)
+        assertEquals("1", links.get(0).chunk)
     }
 
     @Test
@@ -94,16 +90,12 @@ class BookLinkTest {
     @Throws(Exception::class)
     fun autoRangeLink() {
         val links = Link.findLinks("genesis 1:1-3")
-        if (links != null) {
-            assertEquals(1, links.size.toLong())
-            assertEquals("genesis", links.get(0).project)
-            assertEquals("1:1-3", links.get(0).arguments)
-            assertEquals("1", links.get(0).chapter)
-            assertEquals("1", links.get(0).chunk)
-            assertEquals("3", links.get(0).lastChunk)
-        } else {
-            throw Exception("Links is null.")
-        }
+        assertEquals(1, links.size.toLong())
+        assertEquals("genesis", links.get(0).project)
+        assertEquals("1:1-3", links.get(0).arguments)
+        assertEquals("1", links.get(0).chapter)
+        assertEquals("1", links.get(0).chunk)
+        assertEquals("3", links.get(0).lastChunk)
     }
 
     @Test
@@ -111,42 +103,38 @@ class BookLinkTest {
     @Throws(Exception::class)
     fun autoMultipleLinks() {
         val links = Link.findLinks("John 1–3; 3:16; 6:14, 44, 46-47; 7:1-5")
-        if (links != null) {
-            assertEquals(6, links.size.toLong())
-            val l1 = links.get(0)
-            assertEquals("John", l1.project)
-            assertEquals("1", l1.chapter)
-            assertEquals(null, l1.chunk)
+        assertEquals(6, links.size.toLong())
+        val l1 = links.get(0)
+        assertEquals("John", l1.project)
+        assertEquals("1", l1.chapter)
+        assertEquals(null, l1.chunk)
 
-            val l2 = links.get(1)
-            assertEquals("John", l2.project)
-            assertEquals("3", l2.chapter)
-            assertEquals("16", l1.chunk)
+        val l2 = links.get(1)
+        assertEquals("John", l2.project)
+        assertEquals("3", l2.chapter)
+        assertEquals("16", l1.chunk)
 
-            val l3 = links.get(2)
-            assertEquals("John", l3.project)
-            assertEquals("6", l3.chapter)
-            assertEquals("14", l1.chunk)
+        val l3 = links.get(2)
+        assertEquals("John", l3.project)
+        assertEquals("6", l3.chapter)
+        assertEquals("14", l1.chunk)
 
-            val l4 = links.get(3)
-            assertEquals("John", l4.project)
-            assertEquals("6", l4.chapter)
-            assertEquals("44", l1.chunk)
+        val l4 = links.get(3)
+        assertEquals("John", l4.project)
+        assertEquals("6", l4.chapter)
+        assertEquals("44", l1.chunk)
 
-            val l5 = links.get(4)
-            assertEquals("John", l5.project)
-            assertEquals("6", l5.chapter)
-            assertEquals("46", l1.chunk)
-            assertEquals("47", l1.lastChunk)
+        val l5 = links.get(4)
+        assertEquals("John", l5.project)
+        assertEquals("6", l5.chapter)
+        assertEquals("46", l1.chunk)
+        assertEquals("47", l1.lastChunk)
 
-            val l6 = links.get(5)
-            assertEquals("John", l6.project)
-            assertEquals("7", l6.chapter)
-            assertEquals("1", l1.chunk)
-            assertEquals("5", l1.lastChunk)
-        } else {
-            throw Exception("Links is null.")
-        }
+        val l6 = links.get(5)
+        assertEquals("John", l6.project)
+        assertEquals("7", l6.chapter)
+        assertEquals("1", l1.chunk)
+        assertEquals("5", l1.lastChunk)
     }
 
     @Test


### PR DESCRIPTION
Fix Kotlin compiler warnings:

- Unnecessary null-safe `?.` calls
- Always-true or -false conditional predicates
- Java enum interop warnings (can be nullable)
- Unused parameters
- Variable name shadowing
- Deprecated API use
- Ambiguous `return@` targets
- Overridden methods with differently named parameters
- Upgrade Gradle
- (Also merge in Travis/Trusty change from #13)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/kotlin-resource-container/11)
<!-- Reviewable:end -->
