### PR TITLE
Treat compiler warnings as errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,9 @@ dependencies {
 
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.allWarningsAsErrors = true
 }
 compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.allWarningsAsErrors = true
 }


### PR DESCRIPTION
If #11 is merged, this will block new warnings from being committed.

Of course, this PR will fail tests, but #15 demonstrates a merge between this and #11 that passes.