### PR TITLE
Add ability to get an inputstream

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/DirectoryAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/DirectoryAccessor.kt
@@ -1,10 +1,15 @@
 package org.wycliffeassociates.resourcecontainer
 
 import java.io.File
+import java.io.InputStream
 import java.io.Reader
 import java.io.Writer
 
 class DirectoryAccessor(private val rootDir: File) : IResourceContainerAccessor {
+    override fun getInputStream(filename: String): InputStream {
+        return getFile(filename).inputStream()
+    }
+
     override fun getReader(filename: String): Reader {
         return getFile(filename).bufferedReader()
     }

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
@@ -1,10 +1,12 @@
 package org.wycliffeassociates.resourcecontainer
 
+import java.io.InputStream
 import java.io.Reader
 import java.io.Writer
 
 interface IResourceContainerAccessor: AutoCloseable {
     fun fileExists(filename: String): Boolean
+    fun getInputStream(filename: String): InputStream
     fun getReader(filename: String): Reader
     fun initWrite()
     fun write(filename: String, writeFunction: (Writer) -> Unit)

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/ZipAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/ZipAccessor.kt
@@ -1,9 +1,6 @@
 package org.wycliffeassociates.resourcecontainer
 
-import java.io.File
-import java.io.FileOutputStream
-import java.io.Reader
-import java.io.Writer
+import java.io.*
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
@@ -59,6 +56,10 @@ class ZipAccessor(
             .map { filename.toInternalFilepath(separator = it) }
             .map { openZipFile().getEntry(it) }
             .firstOrNull()
+    }
+
+    override fun getInputStream(filename: String): InputStream {
+        return openZipFile().getInputStream(getEntry(filename))
     }
 
     override fun getReader(filename: String): Reader {


### PR DESCRIPTION
For binary file formats like audio or images, accessing files as an input stream is needed.

Currently the needs is with regards to accessing mp3 or wav files included in the media manifest and contained locally within the resource container.