### PR TITLE
Bulk insert files into the container

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/DirectoryAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/DirectoryAccessor.kt
@@ -25,6 +25,12 @@ class DirectoryAccessor(private val rootDir: File) : IResourceContainerAccessor 
         writeFunction(getFile(filename).outputStream())
     }
 
+    override fun write(files: Map<String, (OutputStream) -> Unit>) {
+        files.entries.forEach { (filename, writeFunction) ->
+            writeFunction(getFile(filename).outputStream())
+        }
+    }
+
     override fun close() {
         // Consider closing all readers/writers here, but it doesn't seem to be needed.
     }

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
@@ -11,6 +11,7 @@ interface IResourceContainerAccessor: AutoCloseable {
     fun getReader(filename: String): Reader
     fun initWrite()
     fun write(filename: String, writeFunction: (OutputStream) -> Unit)
+    fun write(files: Map<String, (OutputStream) -> Unit>)
     /** The RC's root relative to the root of the filesystem, or null if they are the same. */
     val root: String?
 }

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/ResourceContainer.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/ResourceContainer.kt
@@ -120,13 +120,13 @@ class ResourceContainer private constructor(val file: File, var config: Config? 
     }
 
     /**
-     * @param files a map that includes the file to add and the path
-     * where the file should be placed within the Resource Container
+     * @param files a map that includes the path where the file should be
+     * placed within the Resource Container as well as the file to insert
      *
      * Adds a files to the Resource Container (such as adding media like audio or images)
      */
-    fun addFilesToContainer(files: Map<File, String>) {
-        val map = files.entries.associate { (file, pathInRC) ->
+    fun addFilesToContainer(files: Map<String, File>) {
+        val map = files.entries.associate { (pathInRC, file) ->
             pathInRC to { ofs: OutputStream ->
                 file.inputStream().use { ifs ->
                     ifs.copyTo(ofs)

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/ResourceContainer.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/ResourceContainer.kt
@@ -86,7 +86,7 @@ class ResourceContainer private constructor(val file: File, var config: Config? 
         accessor.initWrite()
         accessor.write(MEDIA_FILENAME) { writeMedia(it) }
     }
-    
+
     private fun writeMedia(writer: OutputStream) {
         val factory = YAMLFactory()
         factory.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
@@ -117,6 +117,24 @@ class ResourceContainer private constructor(val file: File, var config: Config? 
                 ifs.copyTo(ofs)
             }
         }
+    }
+
+    /**
+     * @param files a map that includes the file to add and the path
+     * where the file should be placed within the Resource Container
+     *
+     * Adds a files to the Resource Container (such as adding media like audio or images)
+     */
+    fun addFilesToContainer(files: Map<File, String>) {
+        val map = files.entries.associate { (file, pathInRC) ->
+            pathInRC to { ofs: OutputStream ->
+                file.inputStream().use { ifs ->
+                    ifs.copyTo(ofs)
+                }
+                Unit
+            }
+        }
+        accessor.write(map)
     }
 
     fun resource() = Resource(

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/ZipAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/ZipAccessor.kt
@@ -115,7 +115,18 @@ class ZipAccessor(
         }
     }
 
-    /** Thread safety warning: This is NOT thread safe, and additionally, write() will close any open Readers. */
+    /**
+     * @param files a map of the file path (with respect to the root of the RC) and a lambda to write
+     * the file to an output stream.
+     *
+     * If the rc has already been written and thus its zip already exists, the write will happen in
+     * a temporary file and then replace the original upon completing the write.
+     *
+     * First, all files in the map will be written. If there was an existing zip, then those zip entries
+     * will be copied, unless they are a file that was contained in the map and are thus outdated.
+     *
+     * ** Thread safety warning: This is NOT thread safe, and additionally, write() will close any open Readers. **
+     */
     override fun write(files: Map<String, (OutputStream) -> Unit>) {
         val doCopy = file.exists()
         val dest = when (doCopy) {


### PR DESCRIPTION
This allows for adding multiple files at once to the resource container; which is significant for zip performance as the write method will require rewriting the entire zip file.