### PR TITLE
Fix bug: Adding non existing directory/file to container (for DirectoryAccessor)

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/DirectoryAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/DirectoryAccessor.kt
@@ -22,12 +22,14 @@ class DirectoryAccessor(private val rootDir: File) : IResourceContainerAccessor 
     }
 
     override fun write(filename: String, writeFunction: (OutputStream) -> Unit) {
-        writeFunction(getFile(filename).outputStream())
+        val file = getFile(filename).also{ it.parentFile.mkdirs() }
+        writeFunction(file.outputStream())
     }
 
     override fun write(files: Map<String, (OutputStream) -> Unit>) {
         files.entries.forEach { (filename, writeFunction) ->
-            writeFunction(getFile(filename).outputStream())
+            val file = getFile(filename).also{ it.parentFile.mkdirs() }
+            writeFunction(file.outputStream())
         }
     }
 


### PR DESCRIPTION
write() function doesn't automatically create directory if the filename include parent directories.
Caller: ResourceContainer -> addFileToContainer( )