### PR TITLE
Fix: Closable output stream for Directory Accessor

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/DirectoryAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/DirectoryAccessor.kt
@@ -23,7 +23,9 @@ class DirectoryAccessor(private val rootDir: File) : IResourceContainerAccessor 
 
     override fun write(filename: String, writeFunction: (OutputStream) -> Unit) {
         val file = getFile(filename).also{ it.parentFile.mkdirs() }
-        writeFunction(file.outputStream())
+        file.outputStream().use {
+            writeFunction(it)
+        }
     }
 
     override fun write(files: Map<String, (OutputStream) -> Unit>) {

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/DirectoryAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/DirectoryAccessor.kt
@@ -23,15 +23,17 @@ class DirectoryAccessor(private val rootDir: File) : IResourceContainerAccessor 
 
     override fun write(filename: String, writeFunction: (OutputStream) -> Unit) {
         val file = getFile(filename).also{ it.parentFile.mkdirs() }
-        file.outputStream().use {
-            writeFunction(it)
+        file.outputStream().use { os ->
+            writeFunction(os)
         }
     }
 
     override fun write(files: Map<String, (OutputStream) -> Unit>) {
         files.entries.forEach { (filename, writeFunction) ->
             val file = getFile(filename).also{ it.parentFile.mkdirs() }
-            writeFunction(file.outputStream())
+            file.outputStream().use { os ->
+                writeFunction(os)
+            }
         }
     }
 


### PR DESCRIPTION
Files written using Directory Access were not properly closed after they finished.