### PR TITLE
Fix lookup path for getInputStreams()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'org.wycliffeassociates'
-version '0.10.0'
+version '0.10.1'
 
 sourceCompatibility = 1.8
 

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
@@ -11,7 +11,7 @@ interface IResourceContainerAccessor: AutoCloseable {
     fun getInputStreams(path: String, extension: String): Map<String, InputStream>
     /**
      * Get the input streams from container.
-     * @param path the lookup path within the resource container.
+     * @param path the path of the resource inside the container. It will include the recursive children of this path.
      * @param extensions the list of filter extensions. Empty list will accept all extensions.
      */
     fun getInputStreams(

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
@@ -11,7 +11,7 @@ interface IResourceContainerAccessor: AutoCloseable {
     fun getInputStreams(path: String, extension: String): Map<String, InputStream>
     /**
      * Get the input streams from container.
-     * @param path the path of the resource inside the container. It will include the recursive children of this path.
+     * @param path the lookup path within the resource container.
      * @param extensions the list of filter extensions. Empty list will accept all extensions.
      */
     fun getInputStreams(

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/ZipAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/ZipAccessor.kt
@@ -79,10 +79,10 @@ class ZipAccessor(
         val zipFile = openZipFile()
         zipFile.entries().iterator().forEach { entry ->
             val fileEntry = File(entry.name)
-            if (
-                (extensions.isEmpty() && fileEntry.extension != "") ||
-                (entry.name.startsWith(pathPrefix) && fileEntry.extension in extensions)
-            ) {
+            val prefixMatched = entry.name.startsWith(pathPrefix)
+            val allExtensionsAccepted = extensions.isEmpty() && fileEntry.extension.isNotEmpty()
+
+            if (prefixMatched && (allExtensionsAccepted || fileEntry.extension in extensions)) {
                 val name = fileEntry.relativeTo(File(pathPrefix)).invariantSeparatorsPath
                 inputStreamMap[name] = zipFile.getInputStream(entry)
             }


### PR DESCRIPTION
Always use the provided path as the look up starting point. Previously, `getInputStreams()` returns most of the files from everywhere in the RC, even though the `path` is specified.