### PR TITLE
List API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'org.wycliffeassociates'
-version '0.10.0'
+version '0.11.0'
 
 sourceCompatibility = 1.8
 

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/DirectoryAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/DirectoryAccessor.kt
@@ -3,6 +3,19 @@ package org.wycliffeassociates.resourcecontainer
 import java.io.*
 
 class DirectoryAccessor(private val rootDir: File) : IResourceContainerAccessor {
+
+    override fun list(path: String): List<String> {
+        val normalizedPath = File(path).normalize().invariantSeparatorsPath
+        val lookupPath = rootDir.resolve(normalizedPath)
+        if (!lookupPath.exists() || lookupPath.isFile) {
+            return listOf()
+        }
+        return lookupPath.walk()
+            .filter { it.isFile }
+            .map { it.invariantSeparatorsPath }
+            .toList()
+    }
+
     override fun getInputStream(filename: String): InputStream {
         return getFile(filename).inputStream()
     }

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
@@ -9,10 +9,10 @@ interface IResourceContainerAccessor: AutoCloseable {
     fun fileExists(filename: String): Boolean
 
     /**
-     * Returns a list of file paths under the given lookup path in the resource container.
+     * Returns a list of file paths that are under the specified path (recursive) in the resource container.
      * If the path denotes a file, an empty list will be returned.
      *
-     * @param path the lookup path within the resource container.
+     * @param path the path of the resource inside the container. It will include the recursive children of this path.
      */
     fun list(path: String): List<String>
     fun getInputStream(filename: String): InputStream

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
@@ -7,6 +7,13 @@ import java.io.Writer
 
 interface IResourceContainerAccessor: AutoCloseable {
     fun fileExists(filename: String): Boolean
+
+    /**
+     * Returns a list of file paths under the given lookup path in the resource container.
+     *
+     * @param path the lookup path within the resource container.
+     */
+    fun list(path: String): List<String>
     fun getInputStream(filename: String): InputStream
     fun getInputStreams(path: String, extension: String): Map<String, InputStream>
     /**

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/IResourceContainerAccessor.kt
@@ -10,6 +10,7 @@ interface IResourceContainerAccessor: AutoCloseable {
 
     /**
      * Returns a list of file paths under the given lookup path in the resource container.
+     * If the path denotes a file, an empty list will be returned.
      *
      * @param path the lookup path within the resource container.
      */

--- a/src/main/kotlin/org/wycliffeassociates/resourcecontainer/ZipAccessor.kt
+++ b/src/main/kotlin/org/wycliffeassociates/resourcecontainer/ZipAccessor.kt
@@ -59,6 +59,20 @@ class ZipAccessor(
             .firstOrNull()
     }
 
+    override fun list(path: String): List<String> {
+        val normalizedPath = File(path).normalize().invariantSeparatorsPath
+        val pathPrefix = if (root.isNullOrEmpty()) {
+            normalizedPath
+        } else {
+            File(root).resolve(normalizedPath).invariantSeparatorsPath
+        }
+
+        val zipFile = openZipFile()
+        return zipFile.entries().toList()
+            .filter { it.name.startsWith(pathPrefix) && File(it.name).extension.isNotEmpty() }
+            .map { it.name }
+    }
+
     override fun getInputStream(filename: String): InputStream {
         return openZipFile().getInputStream(getEntry(filename))
     }

--- a/src/test/kotlin/DirectoryAccessorTest.kt
+++ b/src/test/kotlin/DirectoryAccessorTest.kt
@@ -1,0 +1,24 @@
+package org.wycliffeassociates.resourcecontainer
+
+import org.junit.Assert
+import org.junit.Test
+import java.io.File
+import java.io.FileNotFoundException
+
+class DirectoryAccessorTest {
+
+    @Test
+    fun testListFiles() {
+        val rcDir = getResourceFile("sng_book_various_content_rc")
+        DirectoryAccessor(rcDir).use { da ->
+            accessorListFilesTestCases.forEach {
+                Assert.assertEquals(it.second, da.list(it.first).size)
+            }
+        }
+    }
+
+    private fun getResourceFile(name: String): File {
+        return javaClass.classLoader.getResource(name)?.file
+            ?.let { File(it) } ?: throw FileNotFoundException("Resource not found: $name")
+    }
+}

--- a/src/test/kotlin/Utils.kt
+++ b/src/test/kotlin/Utils.kt
@@ -1,0 +1,10 @@
+package org.wycliffeassociates.resourcecontainer
+
+val accessorListFilesTestCases = listOf(
+    "" to 5,
+    "." to 5,
+    "content" to 4,
+    "content/c01" to 1,
+    "non-existing" to 0,
+    "path_is_a_file.mp3" to 0
+)

--- a/src/test/kotlin/ZipAccessorTest.kt
+++ b/src/test/kotlin/ZipAccessorTest.kt
@@ -1,0 +1,25 @@
+package org.wycliffeassociates.resourcecontainer
+
+import org.junit.Assert
+import org.junit.Test
+import java.io.File
+import java.io.FileNotFoundException
+
+class ZipAccessorTest {
+
+    @Test
+    fun testListFiles() {
+        val rcFile = getResourceFile("sng_book_various_content_rc.zip")
+
+        ZipAccessor(rcFile).use { zip ->
+            accessorListFilesTestCases.forEach {
+                Assert.assertEquals(it.second, zip.list(it.first).size)
+            }
+        }
+    }
+
+    private fun getResourceFile(name: String): File {
+        return javaClass.classLoader.getResource(name)?.file
+            ?.let { File(it) } ?: throw FileNotFoundException("Resource not found: $name")
+    }
+}


### PR DESCRIPTION
Adds the ability to get the files (paths) located under a specified path from the RC. This simplifies `getInputStreams()` when the use case only needs the names.